### PR TITLE
Add transform-es2015-computed-properties babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
     "transform-es2015-parameters",
     "transform-es2015-spread",
     "transform-es2015-modules-commonjs",
+    "transform-es2015-computed-properties"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,6 +237,16 @@
         "lodash": "4.17.4"
       }
     },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
+    },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-plugin-check-es2015-constants": "^6.22.0",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+    "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
     "babel-plugin-transform-es2015-function-name": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-es2015-parameters": "^6.24.1",


### PR DESCRIPTION
```
root@2a341de95b90:/opt/phoenix/packages/chat# npm run build

> chat@1.7.1 build /opt/phoenix/packages/chat
> react-scripts build

Creating an optimized production build...
Failed to compile.

Failed to minify the code from this file:

        ../utils/node_modules/re-select/lib/index.js:91

Read more here: http://bit.ly/2tRViJ9

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chat@1.7.1 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the chat@1.7.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2018-02-22T05_52_04_494Z-debug.log
```

fix 这个问题